### PR TITLE
fix crash and claim assist

### DIFF
--- a/BingoClient/BingoMonitor.cs
+++ b/BingoClient/BingoMonitor.cs
@@ -228,7 +228,6 @@ namespace Celeste.Mod.BingoClient {
             { "Grabless 3A", null }, // generated
             { "10 Berries in 4 Chapters", () => HasNBerriesInChapters(10, 4) },
             { "All Collectibles in 3A", () => (HasNBerriesInChapter(25, 3, false)*25f + HasCassette(3) + HasHeart(3, 0)) / 27f },
-            { "Grabless Rock Bottom", null }, // generated
             { "Easteregg room in Reflection", () => HasFlag("room:easteregg") },
             { "Easteregg Room in Reflection", () => HasFlag("room:easteregg") },
             { "4 Seeded Berries", () => HasNSeedBerries(4) },

--- a/BingoClient/BingoState.cs
+++ b/BingoClient/BingoState.cs
@@ -192,6 +192,15 @@ namespace Celeste.Mod.BingoClient {
 
             var seen = new HashSet<BingoVariant>();
             foreach (var square in Instance.Board) {
+                if(square.Text == "Grabless Rock Bottom" ||  square.Text == "Grabless Rock Bottom (6A/6B Checkpoint)")
+                {
+                    if((area.ID == 6) && ((int)area.Mode == 0 && checkpoint == 4) ||
+                                        ((int)area.Mode == 1 && checkpoint == 2)) {
+                        yield return BingoVariant.NoGrab;
+                        continue;
+                    }
+                }
+
                 if (!BingoMonitor.ObjectiveVariants.TryGetValue(square.Text, out var variants)) {
                     continue;
                 }


### PR DESCRIPTION
Fix a crash due to duplicate Grabless Rock Bottom objectives, and a hacky fix for claim assist on those objectives.